### PR TITLE
Middleware as a mass noun

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ a _view_ / renderer, Flysystem _filesystems_, a PDO _database_ source, and a _tr
         -   [Template Request Controller](#template-request-controller)
         -   [Route API](#route-api)
         -   [Routable objects](#routable-objects)
-    -   [Middlewares](#middlewares)
+    -   [Middleware](#middleware)
     -   [Charcoal Binary](#charcoal-binary)
     -   [PHPUnits Tests](#phpunit-tests)
 -   [Service Providers](#service-providers)
@@ -606,20 +606,46 @@ Routables are called last (only if no explicit routes match fisrt). If no routab
 
 > The [`charcoal-cms`](https://github.com/locomotivemtl/charcoal-cms) module contains many good examples of _routable_ objects.
 
-## Middlewares
+## Middleware
 
-Just like routes (or everything else "Charcoal", really...), _middlewares_ are set up through the app's _config_.
+Just like routes (or everything else "Charcoal", really...), _middleware_ are set up through the app's _config_.
 
-To be enabled, middlewares must be "active" and they must be accessible from the app's `container`.
+To be enabled, middleware must be "active" and must be accessible from the application's service container.
 
-For example
+For example, the Charcoal App package provides two components:
 
-There are 2 middlewares provided by default in the `app` module:
+- PHP Class: `\Charcoal\App\Middleware\CacheMiddleware`
+  Service Key: `charcoal/app/middleware/cache`
+- PHP Class: `\Charcoal\App\Middleware\Cache\IpMiddleware`
+  Service Key: `charcoal/app/middleware/ip`
 
-- `\Charcoal\App\Middleware\CacheMiddleware`
-- `\Charcoal\App\Middleware\Cache\IpMiddleware`
+Which can be added like so in your application's configset:
 
-Other Charcoal modules may provide more middlewares (for example, language detection in `charcoal-translator`).
+```json
+{
+    "middleware": {
+        "charcoal/app/middleware/cache": {
+            "active": true,
+            "included_path": "*",
+            "excluded_path": [
+                "~^/admin\\b~"
+            ],
+            "ignored_query": "*",
+            "ttl": 3600
+        },
+        "charcoal/app/middleware/ip": {
+            "active": false,
+            "blacklist": [],
+            "whitelist": [],
+            "blacklisted_redirect": null,
+            "not_whitelisted_redirect": null,
+            "fail_on_invalid_ip": false
+        }
+    }
+}
+```
+
+Other Charcoal modules may provide additional middleware (for example, language detection in `charcoal-translator`).
 
 ## Charcoal Binary
 
@@ -698,7 +724,7 @@ Example of a module configuration:
     "service_providers": [
         "foo/bar/service-provider/test"
     ],
-    "middlewares": {}
+    "middleware": {}
 }
 ```
 

--- a/src/Charcoal/App/App.php
+++ b/src/Charcoal/App/App.php
@@ -9,6 +9,7 @@ use RuntimeException;
 
 // Dependency from 'Slim'
 use Slim\App as SlimApp;
+use Slim\Exception\ContainerValueNotFoundException;
 
 // Dependencies from 'PSR-3' (Logging)
 use Psr\Log\LoggerAwareInterface;
@@ -221,8 +222,8 @@ class App extends SlimApp implements
         // Setup routable
         $this->setupRoutables();
 
-        // Setup middlewares
-        $this->setupMiddlewares();
+        // Setup middleware
+        $this->setupMiddleware();
     }
 
 
@@ -270,24 +271,24 @@ class App extends SlimApp implements
     }
 
     /**
-     * @throws RuntimeException If the middleware was not set properly on the container.
+     * @throws ContainerValueNotFoundException No container entry was found for the middleware.
      * @return void
      */
-    protected function setupMiddlewares()
+    protected function setupMiddleware()
     {
         $container = $this->getContainer();
-        $middlewaresConfig = $container['config']['middlewares'];
-        if (!$middlewaresConfig) {
+        $middlewareConfig = $container['config']['middleware'];
+        if (!$middlewareConfig) {
             return;
         }
-        foreach ($middlewaresConfig as $id => $opts) {
+        foreach ($middlewareConfig as $key => $opts) {
             if (isset($opts['active']) && $opts['active'] === true) {
-                if (!isset($container['middlewares/'.$id])) {
-                    throw new RuntimeException(
-                        sprintf('Middleware "%s" is not set on container.', $id)
+                if (!isset($container[$key])) {
+                    throw new ContainerValueNotFoundException(
+                        sprintf('Middleware "%s" is not defined on the container.', $key)
                     );
                 }
-                $this->add($container['middlewares/'.$id]);
+                $this->add($container[$key]);
             }
         }
     }

--- a/src/Charcoal/App/ServiceProvider/AppServiceProvider.php
+++ b/src/Charcoal/App/ServiceProvider/AppServiceProvider.php
@@ -290,8 +290,8 @@ class AppServiceProvider implements ServiceProviderInterface
          * @param Container $container A Pimple DI Container.
          * @return CacheMiddleware
          */
-        $container['middlewares/charcoal/app/middleware/cache'] = function (Container $container) {
-            $cacheConfig = $container['config']['middlewares']['charcoal/app/middleware/cache'];
+        $container['charcoal/app/middleware/cache'] = function (Container $container) {
+            $cacheConfig = $container['config']['middleware']['charcoal/app/middleware/cache'];
             $middlewareConfig = array_replace($cacheConfig, ['cache'=>$container['cache']]);
             return new CacheMiddleware($middlewareConfig);
         };
@@ -300,8 +300,8 @@ class AppServiceProvider implements ServiceProviderInterface
          * @param Container $container A Pimple DI Container.
          * @return IpMiddleware
          */
-        $container['middlewares/charcoal/app/middleware/ip'] = function(container $container) {
-            $middlewareConfig = $container['config']['middlewares']['charcoal/app/middleware/ip'];
+        $container['charcoal/app/middleware/ip'] = function(container $container) {
+            $middlewareConfig = $container['config']['middleware']['charcoal/app/middleware/ip'];
             return new IpMiddleware($middlewareConfig);
         };
     }


### PR DESCRIPTION
Changes:
- Corrected "middlewares" to "middleware"
- Simplified middleware configset, the "middleware/" prefix is unnecessary for container keys.
  <small>By dropping the prefix, we take better advantage of our snake_case v. CamelCase features if ever we eventually upgrade to a more mature (and real) dependency injection container</small>
- Replaced `RuntimeException` with `ContainerValueNotFoundException` when middleware not found to be more in line with PSR-11 recommendations
- Updated README with service container definitions and usage for middleware