### PR TITLE
Cleanup CacheConfig, CacheMiddleware, IpMiddleware

### DIFF
--- a/src/Charcoal/App/Config/CacheConfig.php
+++ b/src/Charcoal/App/Config/CacheConfig.php
@@ -2,10 +2,9 @@
 
 namespace Charcoal\App\Config;
 
-// Dependencies from `PHP`
 use InvalidArgumentException;
 
-// Module `charcoal-config` dependencies
+// From 'charcoal-config'
 use Charcoal\Config\AbstractConfig;
 
 /**
@@ -14,27 +13,32 @@ use Charcoal\Config\AbstractConfig;
 class CacheConfig extends AbstractConfig
 {
     /**
+     * Human-readable intervals in seconds.
+     */
+    const HOUR_IN_SECONDS = 3600;
+    const DAY_IN_SECONDS  = 86400;
+    const WEEK_IN_SECONDS = 604800;
+
+    /**
+     * Cache driver(s).
+     *
      * @var array
      */
-    private $types = ['memory'];
+    private $types = [ 'memory' ];
 
     /**
-     * The default TTL, in seconds.
-     * 10 days by default.
+     * Time-to-live in seconds.
      *
-     * @var integer $defaultTtl
+     * @var integer
      */
-    private $defaultTtl = 864000;
+    private $defaultTtl = self::WEEK_IN_SECONDS;
 
     /**
-     * @var string $prefix
+     * Cache namespace.
+     *
+     * @var string
      */
     private $prefix = 'charcoal';
-
-    /**
-     * @var array
-     */
-    public $middleware;
 
     /**
      * @return array
@@ -42,32 +46,9 @@ class CacheConfig extends AbstractConfig
     public function defaults()
     {
         return [
-            'types'         => ['memory'],
-            'default_ttl'   => 864000,
-            'prefix'        => 'charcoal',
-            'middleware'    => $this->middlewareDefaults()
-        ];
-    }
-
-    /**
-     * @return array
-     */
-    private function middlewareDefaults()
-    {
-        return [
-            'active'         => true,
-            'included_path'  => null,
-            'excluded_path'  => null,
-            'methods'        => [
-                'GET'
-            ],
-            'status_codes'   => [
-                200
-            ],
-            'ttl'            => 0,
-            'included_query' => null,
-            'excluded_query' => null,
-            'ignored_query'  => null
+            'types'       => [ 'memory' ],
+            'default_ttl' => self::WEEK_IN_SECONDS,
+            'prefix'      => 'charcoal'
         ];
     }
 
@@ -176,24 +157,5 @@ class CacheConfig extends AbstractConfig
     public function prefix()
     {
         return $this->prefix;
-    }
-
-    /**
-     * @param array $middleware The cache middleware configuration.
-     * @return CacheConfig Chainable
-     */
-    public function setMiddleware(array $middleware)
-    {
-        $middleware = array_merge($this->middlewareDefaults(), $middleware);
-        $this->middleware = $middleware;
-        return $this;
-    }
-
-    /**
-     * @return array
-     */
-    public function middleware()
-    {
-        return $this->middleware;
     }
 }

--- a/src/Charcoal/App/Middleware/CacheMiddleware.php
+++ b/src/Charcoal/App/Middleware/CacheMiddleware.php
@@ -2,12 +2,15 @@
 
 namespace Charcoal\App\Middleware;
 
-// Dependencies from 'PSR-6' (Caching)
+// From PSR-6
 use Psr\Cache\CacheItemPoolInterface;
 
-// Dependencies from 'PSR-7' (HTTP Messaging)
-use \Psr\Http\Message\RequestInterface;
-use \Psr\Http\Message\ResponseInterface;
+// From PSR-7
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+// From 'charcoal-app'
+use Charcoal\App\Config\CacheConfig;
 
 /**
  * The cache loader middleware attempts to load cache from the request's path (route).
@@ -27,11 +30,14 @@ class CacheMiddleware
 {
     /**
      * PSR-6 cache item pool.
+     *
      * @var CacheItemPool
      */
     private $cachePool;
 
     /**
+     * Time-to-live in seconds.
+     *
      * @var integer
      */
     private $cacheTtl;
@@ -85,40 +91,46 @@ class CacheMiddleware
      */
     public function __construct(array $data)
     {
-        $defaults = [
-            'included_path'  => '*',
-            'excluded_path'  => [
-                '~^/admin\b~'
-            ],
-            'methods'        => [
-                'GET'
-            ],
-            'status_codes'   => [
-                200
-            ],
-            'ttl'            => 864000,
-// 24 hours
-            'included_query' => null,
-            'excluded_query' => null,
-            'ignored_query'  => null,
-            'headers'        => true
-        ];
-        $data = array_replace($defaults, $data);
+        $data = array_replace($this->defaults(), $data);
 
         $this->cachePool = $data['cache'];
-        $this->cacheTtl = $data['ttl'];
+        $this->cacheTtl  = $data['ttl'];
 
         $this->includedPath = $data['included_path'];
         $this->excludedPath = $data['excluded_path'];
 
-        $this->methods = $data['methods'];
+        $this->methods     = $data['methods'];
         $this->statusCodes = $data['status_codes'];
 
         $this->includedQuery = $data['included_query'];
         $this->excludedQuery = $data['excluded_query'];
-        $this->ignoredQuery = $data['ignored_query'];
+        $this->ignoredQuery  = $data['ignored_query'];
 
         $this->headers = $data['headers'];
+    }
+
+    /**
+     * Default middleware options.
+     *
+     * @return array
+     */
+    public function defaults()
+    {
+        return [
+            'ttl'            => CacheConfig::DAY_IN_SECONDS,
+
+            'included_path'  => '*',
+            'excluded_path'  => [ '~^/admin\b~' ],
+
+            'methods'        => [ 'GET' ],
+            'status_codes'   => [ 200 ],
+
+            'included_query' => null,
+            'excluded_query' => null,
+            'ignored_query'  => null,
+
+            'headers'        => true
+        ];
     }
 
     /**
@@ -129,7 +141,8 @@ class CacheMiddleware
      * Simply: if the cache for the route exists, it will be used to display the page.
      * The `$next` callback will not be called, therefore stopping the middleware stack.
      *
-     * To generate the cache used in this middleware, @see \Charcoal\App\Middleware\CacheGeneratorMiddleware.
+     * To generate the cache used in this middleware,
+     * @see \Charcoal\App\Middleware\CacheGeneratorMiddleware.
      *
      * @param RequestInterface  $request  The PSR-7 HTTP request.
      * @param ResponseInterface $response The PSR-7 HTTP response.
@@ -149,6 +162,7 @@ class CacheMiddleware
             foreach ($cached['headers'] as $name => $header) {
                 $response = $response->withHeader($name, $header);
             }
+
             return $response;
         } else {
             $response = $next($request, $response);
@@ -156,9 +170,11 @@ class CacheMiddleware
             if ($this->isActive($request, $response) === false) {
                 return $response;
             }
+
             if ($this->isPathIncluded($path) === false) {
                 return $response;
             }
+
             if ($this->isPathExcluded($path) === true) {
                 return $response;
             }
@@ -174,13 +190,12 @@ class CacheMiddleware
                 return $response;
             }
 
-
             // Nothing has excluded the cache so far: add it to the pool.
             $cacheItem = $this->cachePool->getItem($cacheKey);
             $cacheItem->expiresAfter($this->cacheTtl);
             $cacheItem = $cacheItem->set([
-                'body'      => (string)$response->getBody(),
-                'headers'   => (array)$response->getHeaders()
+                'body'    => (string)$response->getBody(),
+                'headers' => (array)$response->getHeaders()
             ]);
             $this->cachePool->save($cacheItem);
 
@@ -200,9 +215,9 @@ class CacheMiddleware
             $keyParams = $this->parseIgnoredParams($queryParams);
             $cacheKey .= '.'.md5(json_encode($keyParams));
         }
+
         return $cacheKey;
     }
-
 
     /**
      * @param RequestInterface  $request  The PSR-7 HTTP request.
@@ -214,9 +229,11 @@ class CacheMiddleware
         if (!in_array($response->getStatusCode(), $this->statusCodes)) {
             return false;
         }
+
         if (!in_array($request->getMethod(), $this->methods)) {
             return false;
         }
+
         return true;
     }
 
@@ -226,15 +243,18 @@ class CacheMiddleware
      */
     private function isPathIncluded($path)
     {
-        if ($this->includedPath == '*') {
+        if ($this->includedPath === '*') {
             return true;
         }
+
         if (!$this->includedPath || empty($this->includedPath)) {
             return false;
         }
+
         if (is_string($this->includedPath)) {
             return !!(preg_match('@'.$this->includedPath.'@', $path));
         }
+
         if (is_array($this->includedPath)) {
             foreach ($this->includedPath as $included) {
                 if (preg_match('@'.$included.'@', $path)) {
@@ -251,15 +271,18 @@ class CacheMiddleware
      */
     private function isPathExcluded($path)
     {
-        if ($this->excludedPath == '*') {
+        if ($this->excludedPath === '*') {
             return true;
         }
+
         if (!$this->excludedPath || empty($this->excludedPath)) {
             return false;
         }
+
         if (is_string($this->excludedPath)) {
             return !!(preg_match('@'.$this->excludedPath.'@', $path));
         }
+
         if (is_array($this->excludedPath)) {
             foreach ($this->excludedPath as $excluded) {
                 if (preg_match('@'.$excluded.'@', $path)) {
@@ -279,12 +302,15 @@ class CacheMiddleware
         if (empty($queryParams)) {
             return true;
         }
-        if ($this->includedQuery == '*') {
+
+        if ($this->includedQuery === '*') {
             return true;
         }
+
         if (!is_array($this->includedQuery) || empty($this->includedQuery)) {
             return false;
         }
+
         return (count(array_intersect_key($queryParams, $this->includedQuery)) > 0);
     }
 
@@ -294,12 +320,14 @@ class CacheMiddleware
      */
     private function isQueryExcluded(array $queryParams)
     {
-        if ($this->excludedQuery == '*') {
+        if ($this->excludedQuery === '*') {
             return true;
         }
+
         if (!is_array($this->excludedQuery) || empty($this->excludedQuery)) {
             return false;
         }
+
         if (count(array_intersect_key($queryParams, array_flip($this->excludedQuery))) > 0) {
             return true;
         }
@@ -311,7 +339,7 @@ class CacheMiddleware
      */
     private function parseIgnoredParams(array $queryParams)
     {
-        if ($this->ignoredQuery == '*') {
+        if ($this->ignoredQuery === '*') {
             $ret = [];
             if (is_array($this->includedQuery)) {
                 foreach ($queryParams as $k => $v) {
@@ -322,15 +350,18 @@ class CacheMiddleware
             }
             return $ret;
         }
+
         if (!is_array($this->ignoredQuery) || empty($this->ignoredQuery)) {
             return $queryParams;
         }
+
         $ret = [];
         foreach ($queryParams as $k => $v) {
             if (!in_array($k, $this->ignoredQuery)) {
                 $ret[$k] = $v;
             }
         }
+
         return $queryParams;
     }
 }

--- a/src/Charcoal/App/Middleware/IpMiddleware.php
+++ b/src/Charcoal/App/Middleware/IpMiddleware.php
@@ -2,9 +2,9 @@
 
 namespace Charcoal\App\Middleware;
 
-// Dependencies from 'PSR-7' (HTTP Messaging)
-use \Psr\Http\Message\RequestInterface;
-use \Psr\Http\Message\ResponseInterface;
+// From PSR-7
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * The IP middleware can restrict access to certain routes to certain IP.
@@ -41,24 +41,33 @@ class IpMiddleware
      */
     public function __construct(array $data)
     {
-        $defaults = [
-            'blacklist' => null,
-            'whitelist' => null,
-
-            'blacklisted_redirect' => null,
-            'not_whitelisted_redirect' => null,
-
-            'fail_on_invalid_ip' => false
-        ];
-        $data = array_merge($defaults, $data);
+        $data = array_merge($this->defaults(), $data);
 
         $this->blacklist = $data['blacklist'];
         $this->whitelist = $data['whitelist'];
 
-        $this->blacklistedRedirect = $data['blacklisted_redirect'];
+        $this->blacklistedRedirect    = $data['blacklisted_redirect'];
         $this->notWhitelistedRedirect = $data['not_whitelisted_redirect'];
 
         $this->failOnInvalidIp = $data['fail_on_invalid_ip'];
+    }
+
+    /**
+     * Default middleware options.
+     *
+     * @return array
+     */
+    public function defaults()
+    {
+        return [
+            'blacklist' => null,
+            'whitelist' => null,
+
+            'blacklisted_redirect'     => null,
+            'not_whitelisted_redirect' => null,
+
+            'fail_on_invalid_ip' => false
+        ];
     }
 
     /**

--- a/src/Charcoal/App/ServiceProvider/AppServiceProvider.php
+++ b/src/Charcoal/App/ServiceProvider/AppServiceProvider.php
@@ -285,9 +285,11 @@ class AppServiceProvider implements ServiceProviderInterface
          * @return CacheMiddleware
          */
         $container['middlewares/charcoal/app/middleware/cache'] = function (Container $container) {
-            $cacheConfig = $container['config']['middlewares']['charcoal/app/middleware/cache'];
-            $middlewareConfig = array_replace($cacheConfig, ['cache'=>$container['cache']]);
-            return new CacheMiddleware($middlewareConfig);
+            $wareConfig  = array_replace(
+                $container['config']['middlewares']['charcoal/app/middleware/cache'],
+                [ 'cache' => $container['cache'] ]
+            );
+            return new CacheMiddleware($wareConfig);
         };
 
         /**
@@ -295,8 +297,8 @@ class AppServiceProvider implements ServiceProviderInterface
          * @return IpMiddleware
          */
         $container['middlewares/charcoal/app/middleware/ip'] = function(container $container) {
-            $middlewareConfig = $container['config']['middlewares']['charcoal/app/middleware/ip'];
-            return new IpMiddleware($middlewareConfig);
+            $wareConfig = $container['config']['middlewares']['charcoal/app/middleware/ip'];
+            return new IpMiddleware($wareConfig);
         };
     }
 

--- a/src/Charcoal/App/ServiceProvider/CacheServiceProvider.php
+++ b/src/Charcoal/App/ServiceProvider/CacheServiceProvider.php
@@ -50,9 +50,8 @@ class CacheServiceProvider implements ServiceProviderInterface
          * @return CacheConfig
          */
         $container['cache/config'] = function (Container $container) {
-            $appConfig = $container['config'];
-
-            $cacheConfig =  new CacheConfig($appConfig['cache']);
+            $appConfig   = $container['config'];
+            $cacheConfig = new CacheConfig($appConfig['cache']);
             return $cacheConfig;
         };
 

--- a/tests/Charcoal/App/Config/CacheConfigTest.php
+++ b/tests/Charcoal/App/Config/CacheConfigTest.php
@@ -2,7 +2,7 @@
 
 namespace Charcoal\Tests\App\Config;
 
-use \Charcoal\App\Config\CacheConfig;
+use Charcoal\App\Config\CacheConfig;
 
 /**
  *
@@ -18,8 +18,12 @@ class CacheConfigTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaults()
     {
-        $this->assertEquals(['memory'], $this->obj->types());
-        $this->assertEquals(864000, $this->obj->defaultTtl());
+        $this->assertEquals((60 * 60), CacheConfig::HOUR_IN_SECONDS);
+        $this->assertEquals((60 * 60 * 24), CacheConfig::DAY_IN_SECONDS);
+        $this->assertEquals((60 * 60 * 24 * 7), CacheConfig::WEEK_IN_SECONDS);
+
+        $this->assertEquals([ 'memory' ], $this->obj->types());
+        $this->assertEquals(CacheConfig::WEEK_IN_SECONDS, $this->obj->defaultTtl());
         $this->assertEquals('charcoal', $this->obj->prefix());
     }
 
@@ -30,15 +34,15 @@ class CacheConfigTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(['memcache', 'noop'], $this->obj->types());
 
         $this->setExpectedException('\InvalidArgumentException');
-        $this->obj->setTypes([false]);
+        $this->obj->setTypes([ false ]);
     }
 
     public function testAddType()
     {
-        $this->assertEquals(['memory'], $this->obj->types());
+        $this->assertEquals([ 'memory' ], $this->obj->types());
         $ret = $this->obj->addType('memcache');
         $this->assertSame($ret, $this->obj);
-        $this->assertEquals(['memory', 'memcache'], $this->obj->types());
+        $this->assertEquals([ 'memory', 'memcache' ], $this->obj->types());
 
         $this->setExpectedException('\InvalidArgumentException');
         $this->obj->addType('foobar');


### PR DESCRIPTION
Changes:
- Moved default middleware options from construct to dedicated defaults method.
- Removed middleware options from `CacheConfig`
- Added constants in `CacheConfig` for default TTL intervals in seconds
- Cleanup classes