### PR TITLE
Change usage of "base_path" and "public_path"

### DIFF
--- a/src/Charcoal/App/AppConfig.php
+++ b/src/Charcoal/App/AppConfig.php
@@ -36,13 +36,6 @@ class AppConfig extends AbstractConfig
     private $projectName;
 
     /**
-     * The base path for the Charcoal installation.
-     *
-     * @var string|null
-     */
-    private $basePath;
-
-    /**
      * The base URL (public) for the Charcoal installation.
      *
      * @var UriInterface|null
@@ -50,11 +43,32 @@ class AppConfig extends AbstractConfig
     private $baseUrl;
 
     /**
+     * The base path for the Charcoal installation.
+     *
+     * @var string|null
+     */
+    private $basePath;
+
+    /**
      * The path to the public / web directory.
      *
      * @var string|null
      */
     private $publicPath;
+
+    /**
+     * The path to the cache directory.
+     *
+     * @var string|null
+     */
+    private $cachePath;
+
+    /**
+     * The path to the logs directory.
+     *
+     * @var string|null
+     */
+    private $logsPath;
 
     /**
      * Whether the debug mode is enabled (TRUE) or not (FALSE).
@@ -249,6 +263,82 @@ class AppConfig extends AbstractConfig
         }
 
         return $this->publicPath;
+    }
+
+    /**
+     * Set the application's absolute path to the cache directory.
+     *
+     * @param  string $path The path to the application's cache directory.
+     * @throws InvalidArgumentException If the argument is not a string.
+     * @return self
+     */
+    public function setCachePath($path)
+    {
+        if ($path === null) {
+            $this->cachePath = null;
+            return $this;
+        }
+
+        if (!is_string($path)) {
+            throw new InvalidArgumentException(
+                'The cache path must be a string'
+            );
+        }
+
+        $this->cachePath = rtrim(realpath($path), '\\/');
+        return $this;
+    }
+
+    /**
+     * Retrieve the application's absolute path to the cache directory.
+     *
+     * @return string The absolute path to the application's cache directory.
+     */
+    public function cachePath()
+    {
+        if ($this->cachePath === null) {
+            $this->cachePath = $this->basePath().DIRECTORY_SEPARATOR.'var'.DIRECTORY_SEPARATOR.'cache';
+        }
+
+        return $this->cachePath;
+    }
+
+    /**
+     * Set the application's absolute path to the logs directory.
+     *
+     * @param  string $path The path to the application's logs directory.
+     * @throws InvalidArgumentException If the argument is not a string.
+     * @return self
+     */
+    public function setLogsPath($path)
+    {
+        if ($path === null) {
+            $this->logsPath = null;
+            return $this;
+        }
+
+        if (!is_string($path)) {
+            throw new InvalidArgumentException(
+                'The logs path must be a string'
+            );
+        }
+
+        $this->logsPath = rtrim(realpath($path), '\\/');
+        return $this;
+    }
+
+    /**
+     * Retrieve the application's absolute path to the logs directory.
+     *
+     * @return string The absolute path to the application's logs directory.
+     */
+    public function logsPath()
+    {
+        if ($this->logsPath === null) {
+            $this->logsPath = $this->basePath().DIRECTORY_SEPARATOR.'var'.DIRECTORY_SEPARATOR.'logs';
+        }
+
+        return $this->logsPath;
     }
 
     /**

--- a/src/Charcoal/App/AppConfig.php
+++ b/src/Charcoal/App/AppConfig.php
@@ -199,7 +199,7 @@ class AppConfig extends AbstractConfig
             );
         }
 
-        $this->basePath = rtrim(realpath($path), '\\/').DIRECTORY_SEPARATOR;
+        $this->basePath = rtrim(realpath($path), '\\/');
         return $this;
     }
 
@@ -233,7 +233,7 @@ class AppConfig extends AbstractConfig
             );
         }
 
-        $this->publicPath = rtrim(realpath($path), '\\/').DIRECTORY_SEPARATOR;
+        $this->publicPath = rtrim(realpath($path), '\\/');
         return $this;
     }
 
@@ -244,8 +244,8 @@ class AppConfig extends AbstractConfig
      */
     public function publicPath()
     {
-        if (!isset($this->publicPath)) {
-            $this->publicPath = $this->basePath().'www'.DIRECTORY_SEPARATOR;
+        if ($this->publicPath === null) {
+            $this->publicPath = $this->basePath().DIRECTORY_SEPARATOR.'www';
         }
 
         return $this->publicPath;

--- a/src/Charcoal/App/Config/FilesystemConfig.php
+++ b/src/Charcoal/App/Config/FilesystemConfig.php
@@ -29,13 +29,13 @@ class FilesystemConfig extends AbstractConfig
             'public' => [
                 'public'    => true,
                 'type'      => 'local',
-                'path'      => './',
+                'path'      => '%app.public_path%',
                 'label'     => 'Public',
             ],
             'private' => [
                 'public'    => false,
                 'type'      => 'local',
-                'path'      => '../',
+                'path'      => '%app.base_path%',
                 'label'     => 'Private',
             ],
         ];

--- a/src/Charcoal/App/Config/LoggerConfig.php
+++ b/src/Charcoal/App/Config/LoggerConfig.php
@@ -60,7 +60,7 @@ class LoggerConfig extends AbstractConfig
             'handlers'  => [
                 'stream' => [
                     'type'   => 'stream',
-                    'stream' => '../logs/charcoal.app.log',
+                    'stream' => '%app.logs_path%/charcoal.app.log',
                     'level'  => null,
                     'bubble' => true,
                     'active' => true,

--- a/src/Charcoal/App/ServiceProvider/FilesystemServiceProvider.php
+++ b/src/Charcoal/App/ServiceProvider/FilesystemServiceProvider.php
@@ -3,7 +3,6 @@
 namespace Charcoal\App\ServiceProvider;
 
 use Exception;
-use LogicException;
 use InvalidArgumentException;
 use UnexpectedValueException;
 
@@ -37,6 +36,7 @@ use League\Flysystem\Sftp\SftpAdapter;
 use League\Flysystem\Memory\MemoryAdapter;
 
 // From 'charcoal-app'
+use Charcoal\App\AppConfig;
 use Charcoal\App\Config\FilesystemConfig;
 
 /**
@@ -142,22 +142,21 @@ class FilesystemServiceProvider implements ServiceProviderInterface
     /**
      * @param  array $config The driver (adapter) configuration.
      * @throws InvalidArgumentException If the path is not defined.
-     * @throws LogicException If the path is not accessible.
      * @return LocalAdapter
      */
     private function createLocalAdapter(array $config)
     {
-        if (!isset($config['path']) || !$config['path']) {
+        if (empty($config['path'])) {
             throw new InvalidArgumentException(
                 'No "path" configured for local filesystem.'
             );
         }
 
-        $path = realpath($config['path']);
-        if ($path === false) {
-            throw new LogicException(
-                'Filesystem "path" does not exist.'
-            );
+        $path = $config['path'];
+        if (is_string($path)) {
+            if (isset($container['config']) && ($container['config'] instanceof AppConfig)) {
+                $path = $container['config']->resolveValue($path);
+            }
         }
 
         $defaults = [
@@ -167,7 +166,7 @@ class FilesystemServiceProvider implements ServiceProviderInterface
         ];
         $config = array_merge($defaults, $config);
 
-        return new LocalAdapter($config['path'], $config['lock'], $config['links'], $config['permissions']);
+        return new LocalAdapter($path, $config['lock'], $config['links'], $config['permissions']);
     }
 
     /**


### PR DESCRIPTION
This pull request does three things:

1. Removes the trailing slash from "base_path" and "public_path".
2. Provides tools for configuring better paths.
3. Provides "cache_path" and a "logs_path".

Since most PHP functions (and `__DIR__`) and many third-party librairies return and expect paths without a trailing slash, it makes sense to expect Charcoal to follow that same behavior.

Many paths in Charcoal are defined as relative but to what is not well documented (the "public_path") and does not always work as expected (such as from the Charcoal CLI or a custom PHP script).

When using the Charcoal CLI from the project's base path, we end up with secondary cache and logs directories in the directory above the base path. If that path is not accessible from the current user, Charcoal will throw an error from being unable to create the aforementioned directories/files.

Ideally, for security reasons, relative paths should always be from the "base_path", instead of the "public_path".

One solution, I propose, to assist with configuring relative paths is with "template tags":

<details>
<summary>Examples</summary>

```diff
- 'path' => './',
+ 'path' => '%app.public_path%'
```

```diff
- 'path' => '../'
+ 'path' => '%app.base_path%'
```

```diff
- 'stream' => '../logs/charcoal.app.log'
+ 'stream' => '%app.logs_path%/charcoal.app.log'
```

```diff
- 'cache_dir' => '../cache/translator'
+ 'cache_dir' => '%app.cache_path%/translator'
```

```diff
- const DEFAULT_CACHE_PATH = '../cache/mustache'
+ const DEFAULT_CACHE_PATH = '%app.cache_path%/charcoal.app.log'
```
</details>

This is accomplished with a new method `AppConfig::resolveValue()` that replaces any supported `%app.*%` tokens:

```php
if (is_string($path)) {
    if (isset($container['config']) && ($container['config'] instanceof AppConfig)) {
        $path = $container['config']->resolveValue($path);
    }
}
```

As for the new configurable paths, "cache_path" and "logs_path", I propose we follow Symfony's default location:

- `$this->basePath().'/var/cache'`
- `$this->basePath().'/var/log'`

---

Both the removal of the trailing slash and recommendations for relative paths requires changes to be made in many Charcoal packages such as:

- **locomotivemtl/charcoal-admin**
  - [ ] Replace "public access" concept with filesystem paths in `ElfinderConnectorAction` and `UploadImageAction`.
  - [ ] Support removed trailing slash in paths and unify static cache path in `StaticWebsite` actions.
- **locomotivemtl/charcoal-core**
  - [ ] Support removed trailing slash in base path for metadata directories in `MetadataLoader`.
- **locomotivemtl/charcoal-property**
  - [ ] Replace "public access" concept with filesystem paths in `FileProperty` and `ImageProperty`.
- **locomotivemtl/charcoal-translator**
  - [ ] Update relative cache path in `TranslatorConfig`.
  - [ ] Support removed trailing slash in base path for translation directories in `TranslatorServiceProvider`.
- **locomotivemtl/charcoal-view**
  - [ ] Update relative cache paths in view engines.
  - [ ] Support removed trailing slash in base path for view directories in `ViewServiceProvider` and `AbstractLoader`.