### PR TITLE
Improve default arguments and interactivity of Scripts

### DIFF
--- a/src/Charcoal/App/Script/AbstractScript.php
+++ b/src/Charcoal/App/Script/AbstractScript.php
@@ -45,6 +45,16 @@ abstract class AbstractScript extends AbstractEntity implements
     const DEFAULT_ARG_DRYRUN      = false;
 
     /**
+     * Command-line argument names available with every command.
+     */
+    const ARG_HELP           = 'help';
+    const ARG_QUIET          = 'quiet';
+    const ARG_VERBOSE        = 'verbose';
+    const ARG_INTERACTIVE    = 'interactive';
+    const ARG_NO_INTERACTION = 'no-interaction';
+    const ARG_DRY_RUN        = 'dry-run';
+
+    /**
      * @var string $ident
      */
     private $ident;
@@ -120,38 +130,49 @@ abstract class AbstractScript extends AbstractEntity implements
         $climate   = $this->climate();
         $arguments = $climate->arguments;
 
-        if ($arguments->defined('help')) {
+        if ($arguments->defined(self::ARG_HELP)) {
             $climate->usage();
             return $response;
         }
 
-        if ($arguments->defined('quiet') && $arguments->defined('verbose')) {
-            $climate->error('You must choose one of --quiet or --verbose');
+        if ($arguments->defined(self::ARG_QUIET) && $arguments->defined(self::ARG_VERBOSE)) {
+            $climate->error(sprintf(
+                'You must choose one of --%s or --%s',
+                self::ARG_QUIET,
+                self::ARG_VERBOSE
+            ));
             return $response;
         }
 
-        if ($arguments->defined('quiet')) {
+        if ($arguments->defined(self::ARG_QUIET)) {
             $this->setQuiet(true);
         }
 
-        if ($arguments->defined('verbose')) {
+        if ($arguments->defined(self::ARG_VERBOSE)) {
             $this->setVerbose(true);
         }
 
-        if ($arguments->defined('interactive') && $arguments->defined('non_interactive')) {
-            $climate->error('You must choose one of --interactive or --no-interaction');
+        if (
+            $arguments->defined(self::ARG_INTERACTIVE) &&
+            $arguments->defined(self::ARG_NO_INTERACTION)
+        ) {
+            $climate->error(sprintf(
+                'You must choose one of --%s or --%s',
+                self::ARG_INTERACTIVE,
+                self::ARG_NO_INTERACTION
+            ));
             return $response;
         }
 
-        if ($arguments->defined('interactive')) {
+        if ($arguments->defined(self::ARG_INTERACTIVE)) {
             $this->setInteractive(true);
         }
 
-        if ($arguments->defined('non_interactive')) {
+        if ($arguments->defined(self::ARG_NO_INTERACTION)) {
             $this->setInteractive(false);
         }
 
-        if ($arguments->defined('dry_run')) {
+        if ($arguments->defined(self::ARG_DRY_RUN)) {
             $this->setDryRun(true);
         }
 
@@ -168,38 +189,38 @@ abstract class AbstractScript extends AbstractEntity implements
     public function defaultArguments()
     {
         return [
-            'help' => [
+            self::ARG_HELP => [
                 'prefix'       => 'h',
-                'longPrefix'   => 'help',
+                'longPrefix'   => self::ARG_HELP,
                 'noValue'      => true,
                 'description'  => 'Display help information.',
             ],
-            'quiet' => [
+            self::ARG_QUIET => [
                 'prefix'       => 'q',
-                'longPrefix'   => 'quiet',
+                'longPrefix'   => self::ARG_QUIET,
                 'noValue'      => true,
                 'description'  => 'Only print error and warning messages.',
             ],
-            'verbose' => [
+            self::ARG_VERBOSE => [
                 'prefix'        => 'v',
-                'longPrefix'    => 'verbose',
+                'longPrefix'    => self::ARG_VERBOSE,
                 'noValue'       => true,
                 'description'   => 'Increase verbosity of messages.',
             ],
-            'interactive' => [
+            self::ARG_INTERACTIVE => [
                 'prefix'       => 'i',
-                'longPrefix'   => 'interactive',
+                'longPrefix'   => self::ARG_INTERACTIVE,
                 'noValue'      => true,
                 'description'  => 'Ask any interactive question.',
             ],
-            'non_interactive' => [
+            self::ARG_NO_INTERACTION => [
                 'prefix'       => 'n',
-                'longPrefix'   => 'no-interaction',
+                'longPrefix'   => self::ARG_NO_INTERACTION,
                 'noValue'      => true,
                 'description'  => 'Do not ask any interactive question.',
             ],
-            'dry_run' => [
-                'longPrefix'   => 'dry-run',
+            self::ARG_DRY_RUN => [
+                'longPrefix'   => self::ARG_DRY_RUN,
                 'noValue'      => true,
                 'description'  => 'This will simulate the script and show you what would happen.',
             ],

--- a/src/Charcoal/App/Script/AbstractScript.php
+++ b/src/Charcoal/App/Script/AbstractScript.php
@@ -137,8 +137,17 @@ abstract class AbstractScript extends AbstractEntity implements
             $this->setVerbose(true);
         }
 
+        if ($arguments->defined('interactive') && $arguments->defined('non_interactive')) {
+            $climate->error('You must choose one of --interactive or --no-interaction');
+            return $response;
+        }
+
         if ($arguments->defined('interactive')) {
             $this->setInteractive(true);
+        }
+
+        if ($arguments->defined('non_interactive')) {
+            $this->setInteractive(false);
         }
 
         if ($arguments->defined('dry_run')) {
@@ -181,6 +190,12 @@ abstract class AbstractScript extends AbstractEntity implements
                 'longPrefix'   => 'interactive',
                 'noValue'      => true,
                 'description'  => 'Ask any interactive question.',
+            ],
+            'non_interactive' => [
+                'prefix'       => 'n',
+                'longPrefix'   => 'no-interaction',
+                'noValue'      => true,
+                'description'  => 'Do not ask any interactive question.',
             ],
             'dry_run' => [
                 'longPrefix'   => 'dry-run',

--- a/src/Charcoal/App/Script/AbstractScript.php
+++ b/src/Charcoal/App/Script/AbstractScript.php
@@ -72,22 +72,22 @@ abstract class AbstractScript extends AbstractEntity implements
     /**
      * @var boolean $quiet
      */
-    private $quiet = self::DEFAULT_ARG_QUIET;
+    private $quiet;
 
     /**
      * @var boolean $verbose
      */
-    private $verbose = self::DEFAULT_ARG_VERBOSE;
+    private $verbose;
 
     /**
      * @var boolean $interactive
      */
-    private $interactive = self::DEFAULT_ARG_INTERACTIVE;
+    private $interactive;
 
     /**
      * @var boolean $dryRun
      */
-    private $dryRun = self::DEFAULT_ARG_DRYRUN;
+    private $dryRun;
 
     /**
      * Return a new CLI script.
@@ -98,6 +98,7 @@ abstract class AbstractScript extends AbstractEntity implements
     {
         $this->setLogger($data['logger']);
         $this->setClimate($data['climate']);
+
         if (isset($data['climate_reader'])) {
             $this->setClimateReader($data['climate_reader']);
         }
@@ -260,7 +261,11 @@ abstract class AbstractScript extends AbstractEntity implements
      */
     public function setQuiet($quiet)
     {
-        $this->quiet = !!$quiet;
+        if ($quiet !== null) {
+            $quiet = (bool)$quiet;
+        }
+
+        $this->quiet = $quiet;
         return $this;
     }
 
@@ -269,6 +274,10 @@ abstract class AbstractScript extends AbstractEntity implements
      */
     public function quiet()
     {
+        if ($this->quiet === null) {
+            return static::DEFAULT_ARG_QUIET;
+        }
+
         return $this->quiet;
     }
 
@@ -278,7 +287,11 @@ abstract class AbstractScript extends AbstractEntity implements
      */
     public function setVerbose($verbose)
     {
-        $this->verbose = !!$verbose;
+        if ($verbose !== null) {
+            $verbose = (bool)$verbose;
+        }
+
+        $this->verbose = $verbose;
         return $this;
     }
 
@@ -287,6 +300,10 @@ abstract class AbstractScript extends AbstractEntity implements
      */
     public function verbose()
     {
+        if ($this->verbose === null) {
+            return static::DEFAULT_ARG_VERBOSE;
+        }
+
         return $this->verbose;
     }
 
@@ -296,7 +313,11 @@ abstract class AbstractScript extends AbstractEntity implements
      */
     public function setInteractive($interactive)
     {
-        $this->interactive = !!$interactive;
+        if ($interactive !== null) {
+            $interactive = (bool)$interactive;
+        }
+
+        $this->interactive = $interactive;
         return $this;
     }
 
@@ -305,6 +326,10 @@ abstract class AbstractScript extends AbstractEntity implements
      */
     public function interactive()
     {
+        if ($this->interactive === null) {
+            return static::DEFAULT_ARG_INTERACTIVE;
+        }
+
         return $this->interactive;
     }
 
@@ -314,7 +339,11 @@ abstract class AbstractScript extends AbstractEntity implements
      */
     public function setDryRun($simulate)
     {
-        $this->dryRun = !!$simulate;
+        if ($simulate !== null) {
+            $simulate = (bool)$simulate;
+        }
+
+        $this->dryRun = $simulate;
         return $this;
     }
 
@@ -323,6 +352,10 @@ abstract class AbstractScript extends AbstractEntity implements
      */
     public function dryRun()
     {
+        if ($this->dryRun === null) {
+            return static::DEFAULT_ARG_DRYRUN;
+        }
+
         return $this->dryRun;
     }
 

--- a/src/Charcoal/App/Script/AbstractScript.php
+++ b/src/Charcoal/App/Script/AbstractScript.php
@@ -37,6 +37,14 @@ abstract class AbstractScript extends AbstractEntity implements
     use LoggerAwareTrait;
 
     /**
+     * Default behaviour of the controller.
+     */
+    const DEFAULT_ARG_QUIET       = false;
+    const DEFAULT_ARG_VERBOSE     = false;
+    const DEFAULT_ARG_INTERACTIVE = false;
+    const DEFAULT_ARG_DRYRUN      = false;
+
+    /**
      * @var string $ident
      */
     private $ident;
@@ -64,22 +72,22 @@ abstract class AbstractScript extends AbstractEntity implements
     /**
      * @var boolean $quiet
      */
-    private $quiet = false;
+    private $quiet = self::DEFAULT_ARG_QUIET;
 
     /**
      * @var boolean $verbose
      */
-    private $verbose = false;
+    private $verbose = self::DEFAULT_ARG_VERBOSE;
 
     /**
      * @var boolean $interactive
      */
-    private $interactive = false;
+    private $interactive = self::DEFAULT_ARG_INTERACTIVE;
 
     /**
      * @var boolean $dryRun
      */
-    private $dryRun = false;
+    private $dryRun = self::DEFAULT_ARG_DRYRUN;
 
     /**
      * Return a new CLI script.

--- a/src/Charcoal/App/Script/AbstractScript.php
+++ b/src/Charcoal/App/Script/AbstractScript.php
@@ -182,9 +182,43 @@ abstract class AbstractScript extends AbstractEntity implements
     }
 
     /**
-     * Retrieve the script's supported arguments.
+     * Filter the default arguments.
      *
+     * Filters:
+     * 1. Removes --quiet if script is quiet by default.
+     * 2. Removes --verbose if script is verbose by default.
+     * 3. Removes either --interactive or --no-interaction depending on
+     *   if script is interactive by default.
+     *
+     * @param  array $arguments A map of argument definitions.
      * @return array
+     */
+    public function filterDefaultArguments(array $arguments)
+    {
+        // [^1]
+        if (static::DEFAULT_ARG_QUIET) {
+            unset($arguments[self::ARG_QUIET]);
+        }
+
+        // [^2]
+        if (static::DEFAULT_ARG_VERBOSE) {
+            unset($arguments[self::ARG_VERBOSE]);
+        }
+
+        // [^3]
+        if (static::DEFAULT_ARG_INTERACTIVE) {
+            unset($arguments[self::ARG_INTERACTIVE]);
+        } else {
+            unset($arguments[self::ARG_NO_INTERACTION]);
+        }
+
+        return $arguments;
+    }
+
+    /**
+     * Retrieve the script's default arguments.
+     *
+     * @return array<string, array>
      */
     public function defaultArguments()
     {
@@ -466,7 +500,7 @@ abstract class AbstractScript extends AbstractEntity implements
      */
     protected function init()
     {
-        $arguments = $this->defaultArguments();
+        $arguments = $this->filterDefaultArguments($this->defaultArguments());
         $this->setArguments($arguments);
     }
 

--- a/src/Charcoal/App/Script/AbstractScript.php
+++ b/src/Charcoal/App/Script/AbstractScript.php
@@ -41,7 +41,7 @@ abstract class AbstractScript extends AbstractEntity implements
      */
     const DEFAULT_ARG_QUIET       = false;
     const DEFAULT_ARG_VERBOSE     = false;
-    const DEFAULT_ARG_INTERACTIVE = false;
+    const DEFAULT_ARG_INTERACTIVE = true;
     const DEFAULT_ARG_DRYRUN      = false;
 
     /**
@@ -472,21 +472,23 @@ abstract class AbstractScript extends AbstractEntity implements
     }
 
     /**
-     * Retrieve an argument either from argument list (if set) or from user input.
+     * Retrieves the value of an argument either
+     * from the argument list (if defined) or
+     * from user input (if interactive).
      *
      * @param  string $argName An argument identifier.
      * @return mixed Returns the argument or prompt value.
      */
     protected function argOrInput($argName)
     {
-        $climate = $this->climate();
+        $cli  = $this->climate();
+        $args = $cli->arguments;
 
-        $value = $climate->arguments->get($argName);
-        if ($value) {
-            return $value;
+        if (!$args->defined($argName) && $this->interactive()) {
+            return $this->input($argName);
         }
 
-        return $this->input($argName);
+        return $args->get($argName);
     }
 
     /**

--- a/src/Charcoal/App/Script/ArgScriptTrait.php
+++ b/src/Charcoal/App/Script/ArgScriptTrait.php
@@ -49,7 +49,7 @@ trait ArgScriptTrait
         $cli  = $this->climate();
         $args = $cli->arguments;
 
-        $ask    = $args->defined('interactive');
+        $ask    = $this->interactive();
         $params = $this->arguments();
         foreach ($params as $key => $param) {
             $setter = $this->setter($key);


### PR DESCRIPTION
### Default Arguments

Added class constants `ARG_*` for the script's default arguments (`--help`, `--quiet`, `--verbose`, `--interactive`, and `--dry-run`), representing the argument name and long prefix. Correspondingly, renamed argument name `dry_run` to `dry-run` to match long prefix.

This should encourage developers to use class constants to reference argument names and long prefixes. The main benefit will be minimizing typos from using, and normalizing, different casing between the argument name (snake_case) and prefix (kebab-case).

Added default argument `--no-interaction` (complement to `--interactive`), useful if a script is marked as interactive by default.

### Default Argument Values (BC: Breaking Change)

Added class constants `DEFAULT_ARG_*` for default values of default arguments (`quiet`, `verbose`, `interactive`, and `dry-run`), allowing sub-classes to override default behaviour.

Changed behaviour of methods `setQuiet()`, `setVerbose()`, `setInteractive()`, and `setDryRun()` to accept `null` as a way to reset to the script's default value.

Changed behaviour of methods `quiet()`, `verbose()`, `interactive()`, and `dryRun()` to return default value (`static::DEFAULT_ARG_*`) if class property is `null`.

Added method `filterDefaultArguments()` (called in `init()`) to remove specific arguments based on default values of class constants:

1. Removes `--quiet` if script is quiet by default (`static::DEFAULT_ARG_QUIET`).
2. Removes `--verbose` if script is verbose by default (`static::DEFAULT_ARG_VERBOSE`).
3. Removes either `--interactive` or `--no-interaction` depending on if script is interactive by default (`static::DEFAULT_ARG_INTERACTIVE`).

Make scripts interactive by default:

```php
// AbstractScript
const DEFAULT_ARG_QUIET       = false;
const DEFAULT_ARG_VERBOSE     = false;
const DEFAULT_ARG_INTERACTIVE = true;
const DEFAULT_ARG_DRYRUN      = false;

// FoobarScript
const DEFAULT_ARG_INTERACTIVE = false;
```

### Interactive Arguments (BC: Breaking Change)

The current behaviour of `argOrInput()` is flawed and limits interactivity:

1. Fetch the argument's defined value or the default value.
2. If the argument's value is truthy, return that.
3. Otherwise, prompt the user for input, then return that.

If the argument has a default value, it does not offer the option to input a different one unless explicitly requested by the script or defined by the user.

I propose the following logic:

1. If the argument is NOT defined AND the script IS interactive:
	1. Prompt the user for input:
		1. If the user DOES provide a value, then return that.
		2. If the user DOES NOT provide a value, fetch the argument's default value, then return that.
2. Otherwise, fetch the argument's defined value or the default value, then return that.